### PR TITLE
[SOF-45] Test documentation generation

### DIFF
--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'SOF-45'
 
 permissions:
   contents: read

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
       - 'SOF-45'
 
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -29,17 +29,18 @@ jobs:
 
       - run: dart doc --output=/tmp/docs
 
+      - name: Setup Pages
         if: github.ref == "refs/heads/master"
-        steps:
-          - name: Setup Pages
-            uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v4
 
-          - name: Upload artifact
-            uses: actions/upload-pages-artifact@v3
-            with:
-              path: '/tmp/docs'
+      - name: Upload artifact
+        if: github.ref == "refs/heads/master"
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '/tmp/docs'
 
-          - name: Deploy to GitHub Pages
-            id: deployment
-            uses: actions/deploy-pages@v4
+      - name: Deploy to GitHub Pages
+        if: github.ref == "refs/heads/master"
+        id: deployment
+        uses: actions/deploy-pages@v4
 

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -29,16 +29,17 @@ jobs:
 
       - run: dart doc --output=/tmp/docs
 
-        if: github.ref == "refs/heads/master":
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
+        if: github.ref == "refs/heads/master"
+        steps:
+          - name: Setup Pages
+            uses: actions/configure-pages@v4
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: '/tmp/docs'
+          - name: Upload artifact
+            uses: actions/upload-pages-artifact@v3
+            with:
+              path: '/tmp/docs'
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          - name: Deploy to GitHub Pages
+            id: deployment
+            uses: actions/deploy-pages@v4
 

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -30,17 +30,17 @@ jobs:
       - run: dart doc --output=/tmp/docs
 
       - name: Setup Pages
-        if: github.ref == "refs/heads/master"
+        if: github.ref == 'refs/heads/master'
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        if: github.ref == "refs/heads/master"
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: '/tmp/docs'
 
       - name: Deploy to GitHub Pages
-        if: github.ref == "refs/heads/master"
+        if: github.ref == 'refs/heads/master'
         id: deployment
         uses: actions/deploy-pages@v4
 

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -1,9 +1,6 @@
 name: Generate documentation
 
-on:
-  push:
-    branches:
-      - 'master'
+on: push
 
 permissions:
   contents: read
@@ -32,6 +29,7 @@ jobs:
 
       - run: dart doc --output=/tmp/docs
 
+        if: github.ref == "refs/heads/master":
       - name: Setup Pages
         uses: actions/configure-pages@v4
 

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -30,6 +30,7 @@ jobs:
           flutter-version: '3.16.x'
           channel: 'stable'
 
+      - run: flutter pub get
       - run: dart doc --output=/tmp/docs
 
       - name: Setup Pages

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -1,11 +1,10 @@
 name: Generate documentation
   
+
 on:
   push:
     branches:
       - 'master'
-      - 'SOF-45'
-
 
 permissions:
   contents: read

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -1,6 +1,9 @@
 name: Generate documentation
-
-on: push
+  
+on:
+  push:
+    branches:
+      - 'master'
 
 permissions:
   contents: read
@@ -30,17 +33,14 @@ jobs:
       - run: dart doc --output=/tmp/docs
 
       - name: Setup Pages
-        if: github.ref == 'refs/heads/master'
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: '/tmp/docs'
 
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/master'
         id: deployment
         uses: actions/deploy-pages@v4
 

--- a/.github/workflows/doc_generation_test.yml
+++ b/.github/workflows/doc_generation_test.yml
@@ -1,0 +1,18 @@
+name: Test documentation generation
+
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dart & Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.16.x'
+          channel: 'stable'
+
+      - run: dart doc --output=/tmp/docs

--- a/.github/workflows/doc_generation_test.yml
+++ b/.github/workflows/doc_generation_test.yml
@@ -15,4 +15,5 @@ jobs:
           flutter-version: '3.16.x'
           channel: 'stable'
 
+      - run: flutter pub get
       - run: dart doc --output=/tmp/docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,4 @@ jobs:
       with:
         flutter-version: '3.16.x'
         channel: 'stable'
-    - run: flutter test
+    - run: flutter test && dart doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,4 @@ jobs:
       with:
         flutter-version: '3.16.x'
         channel: 'stable'
-    - run: flutter test && dart doc
+    - run: flutter test


### PR DESCRIPTION
This PR adds a test that will check that documentation *can* be generated. This prevents changes that can break documentation generation from being merged to master.

Generate documentation for all branches (but do not upload unless master is changed)